### PR TITLE
Add unicode support to regexp in ScalarScanner#tokenize

### DIFF
--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -34,7 +34,7 @@ module Psych
 
       # Check for a String type, being careful not to get caught by hash keys, hex values, and
       # special floats (e.g., -.inf).
-      if string.match?(/^[^\d\.:-]?[A-Za-z_\s!@#\$%\^&\*\(\)\{\}\<\>\|\/\\~;=]+/) || string.match?(/\n/)
+      if string.match?(%r{^[^\d.:-]?(?:[[:alpha:]]|[_\s!@#$%\^&*(){}<>|/\\~;=])+}) || string.match?(/\n/)
         return string if string.length > 5
 
         if string.match?(/^[^ytonf~]/i)

--- a/test/psych/test_scalar_scanner.rb
+++ b/test/psych/test_scalar_scanner.rb
@@ -133,5 +133,27 @@ module Psych
       assert_equal 0x123456789abcdef, ss.tokenize('0x_12_,34,_56,_789abcdef')
       assert_equal 0x123456789abcdef, ss.tokenize('0x12_,34,_56,_789abcdef__')
     end
+
+    class MatchCallCounter < String
+      attr_reader :match_call_count
+
+      def match?(pat)
+        @match_call_count ||= 0
+        @match_call_count += 1
+        super
+      end
+    end
+
+    def test_scan_ascii_matches_quickly
+      ascii = MatchCallCounter.new('abcdefghijklmnopqrstuvwxyz')
+      ss.tokenize(ascii)
+      assert_equal 1, ascii.match_call_count
+    end
+
+    def tests_scan_unicode_matches_quickly
+      unicode = MatchCallCounter.new('鳥かご関連用品')
+      ss.tokenize(unicode)
+      assert_equal 1, unicode.match_call_count
+    end
   end
 end


### PR DESCRIPTION
This PR switches out `A-Za-z` in favour of `[[:alpha:]]` to achieve better support for non-latin character sets.

During some development on Shopify/shopify we noticed that `Object#to_yaml` calls were much slower for the locales `ja, ko, th, zh-CN, zh-TW`.

After some profiling work, it turned out that the `#tokenize` method in of the ScalarScanner was only matching against ascii characters, so unicode strings would hit all 11 branches of the conditional and just fall out at the end.